### PR TITLE
repeat_interleave copy.deepcopy _get_op_attributes

### DIFF
--- a/python/aitemplate/compiler/ops/tensor/repeat_interleave.py
+++ b/python/aitemplate/compiler/ops/tensor/repeat_interleave.py
@@ -33,3 +33,6 @@ class repeat_interleave(Operator):
         func_key = f"{target.name()}.{self._attrs['op']}.gen_function"
         func = registry.get(func_key)
         return func(self._attrs)
+
+    def _get_op_attributes(self):
+        return {"repeats": self._attrs["repeats"], "repeat_dim": self._attrs["repeat_dim"]}


### PR DESCRIPTION
`_get_op_attributes` is required on all of a Tensor's ops for `copy.deepcopy` to work